### PR TITLE
Implement matching skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+status.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # literature_footnote_classification
+
+Dieses Projekt dient als Beispiel für die Zuordnung von Fußnoten zu ihren zugehörigen Literatureinträgen.
+Die Module in `src/` implementieren das Einlesen der Daten, den (simulierten) Zugriff auf ein
+Language Model und die Logik für die Zuordnung.

--- a/data/footnotes.html
+++ b/data/footnotes.html
@@ -1,0 +1,36 @@
+<h1>1 Einleitung</h1>
+<div id="Vgl. Casheekar et al. 2024, S. 2 Z. 40 ff." class="original_text">
+ In nur wenigen Jahren hat sich ein regelrechter Boom in der Entwicklung von Künstliche Intel-
+ ligenz (KI)-Assistenten vollzogen. Darunter sind insbesondere Chatbots und Code-Completion-
+ Systeme rasant vorangeschritten
+</div>
+<div id="Vgl. Contreras, Guerra, De Lara 2024, S. 2 f." class="original_text">
+ . Während Chatbots in der Regel für allgemeine Anwendungs-
+ fälle im Dialog entwickelt werden, sind Code-Completion-Systeme spezialisiert auf die Vervoll-
+ ständigung von Code-Snippets und somit der Unterstützung von Softwareentwicklern und Soft-
+ wareentwicklerinnen bei ihrer täglichen Arbeit
+</div>
+ . Damit verändert sich die Art und Weise, wie
+ Softwarecode entwickelt wird, nachhaltig. Die vorliegende Arbeit beschäftigt sich mit der Frage,
+ wie ein vorhandenes Code-Completion-System an die spezifischen Bedürfnisse und Anforderun-
+ gen eines Unternehmens mit hohen Datenschutzvorgaben angepasst werden kann. Dies soll be-
+ werkstelligt werden, indem geprüft wird, inwiefern eine Anpassung der Lösung notwendig ist, um
+ die Anforderungen zu erfüllen. Anschließend soll die Lösung nach ihrer Implementierung evaluiert
+ werden, um die Qualität der Anpassung zu überprüfen und weitere Verbesserungsmöglichkeiten
+ zu dokumentieren.
+<h2>1.1 Hintergrund</h2>
+<div id="Vgl. Guo et al. 2024, S. 1" class="original_text">
+ Genau wie die Digitalisierung im KI-getriebenen Kontext die Gesellschaft bereits in vielen ande-
+ ren Arbeitsbereichen verändert hat, etwa in der Medizin mit AlphaFold
+</div>
+<div id="Vgl. Bettis 2024, S. 1f., 48–51" class="original_text">Genau wie die Digitalisierung im KI-getriebenen Kontext die Gesellschaft bereits in vielen ande-
+ ren Arbeitsbereichen verändert hat, etwa in der Medizin mit AlphaFold oder im Journalismus
+ mit Chatbot-Assistenten wie ChatGPT oder Gemini</div>
+<div id="Vgl. Sergeyuk, Titov, Izadi 2024, S. 97" class="original_text">
+ , so verändert sie auch die Softwareent-
+ wicklung. Während Chatbots heute schon in der Lage sind, komplexe Programmieraufgaben zu
+ lösen
+</div>
+<div id="Vgl. Xu, Vasilescu, Neubig 2022, S. 26 f." class="original_text">
+ , so fehlt ihnen die direkte Integration in die Entwicklungsumgebung
+</div>

--- a/data/literature.json
+++ b/data/literature.json
@@ -1,0 +1,46 @@
+[
+  {
+    "segment_id": "seg-1",
+    "titel": "A Comparison of Natural Language Understanding Platforms for Chatbots in Software Engineering",
+    "autor": {
+      "vorname": "Ahmad",
+      "nachname": "Abdellatif"
+    },
+    "doi": "10.1109/TSE.2021.3078384",
+    "url": "https://ieeexplore.ieee.org/document/9426404/",
+    "erscheinungsjahr": 2022
+  },
+  {
+    "segment_id": "seg-2",
+    "titel": "Rule-Based Expert Systems",
+    "autor": {
+      "vorname": "Ajith",
+      "nachname": "Abraham"
+    },
+    "doi": "10.1002/0471497398.mm422",
+    "url": "https://onlinelibrary.wiley.com/doi/10.1002/0471497398.mm422",
+    "erscheinungsjahr": 2005
+  },
+  {
+    "segment_id": "seg-3",
+    "titel": "Agentic AI: Autonomous Intelligence for Complex Goals—A Comprehensive Survey",
+    "autor": {
+      "vorname": "Deepak Bhaskar",
+      "nachname": "Acharya"
+    },
+    "doi": "10.1109/ACCESS.2025.3532853",
+    "url": "https://ieeexplore.ieee.org/abstract/document/10849561",
+    "erscheinungsjahr": 2025
+  },
+  {
+    "segment_id": "seg-4",
+    "titel": "History of generative Artificial Intelligence (AI) chatbots: past, present, and future development",
+    "autor": {
+      "vorname": "Md",
+      "nachname": "Al-Amin"
+    },
+    "doi": "10.48550/arXiv.2402.05122",
+    "url": "http://arxiv.org/abs/2402.05122",
+    "erscheinungsjahr": 2024
+  }
+]

--- a/prompt_templates/basic_prompt.txt
+++ b/prompt_templates/basic_prompt.txt
@@ -1,0 +1,2 @@
+Please map the following footnotes to the literature entry.
+Return JSON in the form {"<entry_key>": ["<footnote_key>", ...]}.

--- a/run.py
+++ b/run.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from src import (
+    load_literature_entries,
+    load_footnotes,
+    LLMClient,
+    DummyAPIClient,
+    StatusManager,
+    Matcher,
+)
+
+if __name__ == "__main__":
+    entries = load_literature_entries(Path("data/literature.json"))
+    footnotes = load_footnotes(Path("data/footnotes.html"))
+
+    status = StatusManager(Path("status.json"))
+    client = LLMClient(DummyAPIClient())
+    matcher = Matcher(client, status)
+
+    result = matcher.match(entries, footnotes)
+    print(result)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,15 @@
+"""Footnote to literature entry matching package."""
+
+from .data_ingestion import load_literature_entries, load_footnotes
+from .llm_client import LLMClient, DummyAPIClient
+from .status_manager import StatusManager
+from .matching_logic import Matcher
+
+__all__ = [
+    "load_literature_entries",
+    "load_footnotes",
+    "LLMClient",
+    "DummyAPIClient",
+    "StatusManager",
+    "Matcher",
+]

--- a/src/data_ingestion.py
+++ b/src/data_ingestion.py
@@ -1,0 +1,55 @@
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+from bs4 import BeautifulSoup
+
+@dataclass
+class LiteratureEntry:
+    segment_id: str
+    title: str
+    author_first: str
+    author_last: str
+    doi: str
+    url: str
+    year: int
+    key: str = field(default="")
+
+@dataclass
+class Footnote:
+    footnote_id: str
+    text: str
+    key: str = field(default="")
+
+
+def load_literature_entries(path: Path) -> List[LiteratureEntry]:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    entries = []
+    for i, item in enumerate(data, start=1):
+        key = f"L{i:05d}"
+        entries.append(
+            LiteratureEntry(
+                segment_id=item.get("segment_id"),
+                title=item.get("titel"),
+                author_first=item.get("autor", {}).get("vorname"),
+                author_last=item.get("autor", {}).get("nachname"),
+                doi=item.get("doi"),
+                url=item.get("url"),
+                year=item.get("erscheinungsjahr"),
+                key=key,
+            )
+        )
+    return entries
+
+
+def load_footnotes(path: Path) -> List[Footnote]:
+    html = path.read_text(encoding="utf-8")
+    soup = BeautifulSoup(html, "html.parser")
+    footnotes = []
+    for i, div in enumerate(soup.find_all("div"), start=1):
+        if not div.get("id"):
+            continue
+        key = f"F{i:05d}"
+        footnotes.append(Footnote(footnote_id=div["id"], text=div.get_text(strip=True), key=key))
+    return footnotes

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -1,0 +1,34 @@
+import json
+from typing import Any, Dict
+
+class LLMValidationError(Exception):
+    pass
+
+
+class LLMClient:
+    def __init__(self, api_client):
+        self.api_client = api_client
+
+    def _send_prompt(self, prompt: str) -> str:
+        """Send prompt using provided API client."""
+        # This is a placeholder for real API call
+        return self.api_client.send(prompt)
+
+    def query(self, prompt: str) -> Dict[str, Any]:
+        """Send prompt twice and verify matching JSON responses."""
+        for attempt in range(2):
+            res1 = self._send_prompt(prompt)
+            res2 = self._send_prompt(prompt)
+            try:
+                j1 = json.loads(res1)
+                j2 = json.loads(res2)
+            except json.JSONDecodeError:
+                continue
+            if j1 == j2:
+                return j1
+        raise LLMValidationError("Failed to obtain valid identical responses")
+
+class DummyAPIClient:
+    def send(self, prompt: str) -> str:
+        """Mock API client for testing."""
+        return json.dumps({"prompt": prompt})

--- a/src/matching_logic.py
+++ b/src/matching_logic.py
@@ -1,0 +1,32 @@
+from typing import Dict, List
+
+from .data_ingestion import LiteratureEntry, Footnote
+from .llm_client import LLMClient
+from .status_manager import StatusManager
+
+
+class Matcher:
+    def __init__(self, llm_client: LLMClient, status: StatusManager):
+        self.llm_client = llm_client
+        self.status = status
+
+    def match(self, entries: List[LiteratureEntry], footnotes: List[Footnote]) -> Dict[str, List[str]]:
+        result: Dict[str, List[str]] = {}
+        for entry in entries:
+            self.status.update("current_entry", entry.key)
+            for i in range(0, len(footnotes), 10):
+                chunk = footnotes[i:i+10]
+                prompt = self._build_prompt(entry, chunk)
+                try:
+                    response = self.llm_client.query(prompt)
+                except Exception as e:
+                    self.status.update("error", str(e))
+                    continue
+                footnote_keys = response.get(entry.key, [])
+                result.setdefault(entry.key, []).extend(footnote_keys)
+        return result
+
+    def _build_prompt(self, entry: LiteratureEntry, footnotes: List[Footnote]) -> str:
+        notes = "\n".join(f"{f.key}: {f.text}" for f in footnotes)
+        prompt = f"Entry: {entry.key} {entry.title}\nFootnotes:\n{notes}"
+        return prompt

--- a/src/status_manager.py
+++ b/src/status_manager.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+
+class StatusManager:
+    def __init__(self, path: Path):
+        self.path = path
+        self.status: Dict[str, str] = {}
+        self._write()
+
+    def update(self, key: str, value: str) -> None:
+        self.status[key] = value
+        self._write()
+
+    def _write(self) -> None:
+        with self.path.open("w", encoding="utf-8") as f:
+            json.dump(self.status, f, indent=2)
+
+    def load(self) -> Dict[str, str]:
+        if self.path.exists():
+            with self.path.open("r", encoding="utf-8") as f:
+                self.status = json.load(f)
+        return self.status


### PR DESCRIPTION
## Summary
- add basic modules to load literature entries and footnotes with IDs
- implement simple LLM client that verifies repeated prompts
- add status manager that writes status to JSON file
- add matcher that splits footnotes in chunks of ten
- include example data and prompt template
- provide run script and improved README

## Testing
- `pytest -q`
- `python run.py`

------
https://chatgpt.com/codex/tasks/task_e_687fbd27ec0083259f1ba7893a44c7c6