### PR TITLE
Add LLM rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,28 @@ Beim Einlesen erhalten alle Literatureinträge einen Schlüssel in der Form `L00
    python -m venv .venv
    source .venv/bin/activate
    ```
+
 3. Benötigte Pakete installieren:
    ```bash
    pip install -r requirements.txt
    ```
+
+## Konfiguration
+Im Projektverzeichnis befindet sich eine Datei `config.json` mit den Einstellungen für das LLM. Beispielinhalt:
+
+```json
+{
+  "api_key": "YOUR_API_KEY",
+  "model": "gpt-4.1-nano",
+  "max_tokens": 500,
+  "temperature": 0.3,
+  "request_interval": 1.0
+}
+```
+
+Ohne `api_key` wird automatisch der `DummyAPIClient` verwendet.
+Der Parameter `request_interval` gibt die minimale Zeit in Sekunden zwischen zwei
+LLM-Aufrufen an und hilft, "Too Many Requests"-Fehler zu vermeiden.
 
 ## Ausführung
 Das Programm kann direkt über `run.py` gestartet werden. Es liest die Daten ein, ruft das (hier simulierte) LLM über den `LLMClient` an und schreibt Fortschrittsinformationen in `status.json`. Die Protokollierung wird zentral durch den `LoggingManager` gesteuert.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,7 @@
+{
+  "api_key": "YOUR_API_KEY",
+  "model": "gpt-4.1-nano",
+  "max_tokens": 500,
+  "temperature": 0.3,
+  "request_interval": 1.0
+}

--- a/run.py
+++ b/run.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import logging
+import json
 
 from src.logging_manager import LoggingManager
 
@@ -7,7 +8,6 @@ from src import (
     load_literature_entries,
     load_footnotes,
     LLMClient,
-    DummyAPIClient,
     StatusManager,
     Matcher,
 )
@@ -15,11 +15,22 @@ from src import (
 if __name__ == "__main__":
     LoggingManager(Path("app.log"))
     logging.debug("Application started")
+
+    # Load configuration
+    config_path = Path("config.json")
+    config = json.loads(config_path.read_text(encoding="utf-8")) if config_path.exists() else {}
+
     entries = load_literature_entries(Path("data/literature.json"))
     footnotes = load_footnotes(Path("data/footnotes.html"))
 
     status = StatusManager(Path("status.json"))
-    client = LLMClient(DummyAPIClient())
+    client = LLMClient(
+        api_key=config.get("api_key"),
+        model=config.get("model", "gpt-4.1-nano"),
+        max_tokens=config.get("max_tokens", 500),
+        temperature=config.get("temperature", 0.3),
+        request_interval=config.get("request_interval", 1.0),
+    )
     matcher = Matcher(client, status)
 
     result = matcher.match(entries, footnotes)


### PR DESCRIPTION
## Summary
- add `request_interval` to `config.json` and document it
- pass new configuration option in `run.py`
- implement waiting queue in `LLMClient` to throttle requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fe20d191c8325a6489e35d47e7739