### PR TITLE
Improve prompt use

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,32 @@ Beim Einlesen erhalten alle Literatureinträge einen Schlüssel in der Form `L00
    python -m venv .venv
    source .venv/bin/activate
    ```
+
 3. Benötigte Pakete installieren:
    ```bash
    pip install -r requirements.txt
    ```
+
+## Konfiguration
+Im Projektverzeichnis befindet sich eine Datei `config.json` mit den Einstellungen für das LLM. Beispielinhalt:
+
+```json
+{
+  "api_key": "YOUR_API_KEY",
+  "model": "gpt-4.1-nano",
+  "max_tokens": 500,
+  "temperature": 0.3,
+  "request_interval": 1.0
+}
+```
+
+Ohne `api_key` wird automatisch der `DummyAPIClient` verwendet.
+Der Parameter `request_interval` gibt die minimale Zeit in Sekunden zwischen zwei
+LLM-Aufrufen an und hilft, "Too Many Requests"-Fehler zu vermeiden.
+
+Der eigentliche Prompt wird aus der Datei `prompt_templates/basic_prompt.txt`
+gelesen und mit den Informationen zu Eintrag und Fußnoten kombiniert. Dort kann
+der Prompttext angepasst werden.
 
 ## Ausführung
 Das Programm kann direkt über `run.py` gestartet werden. Es liest die Daten ein, ruft das (hier simulierte) LLM über den `LLMClient` an und schreibt Fortschrittsinformationen in `status.json`. Die Protokollierung wird zentral durch den `LoggingManager` gesteuert.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,7 @@
+{
+  "api_key": "YOUR_API_KEY",
+  "model": "gpt-4.1-nano",
+  "max_tokens": 500,
+  "temperature": 0.3,
+  "request_interval": 1.0
+}

--- a/prompt_templates/basic_prompt.txt
+++ b/prompt_templates/basic_prompt.txt
@@ -1,2 +1,4 @@
 Please map the following footnotes to the literature entry.
-Return JSON in the form {"<entry_key>": ["<footnote_key>", ...]}.
+Return **only** a valid JSON object in the form
+{"<entry_key>": ["<footnote_key>", ...]}.
+Do not include any explanations or additional text.

--- a/run.py
+++ b/run.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import logging
+import json
 
 from src.logging_manager import LoggingManager
 
@@ -7,7 +8,6 @@ from src import (
     load_literature_entries,
     load_footnotes,
     LLMClient,
-    DummyAPIClient,
     StatusManager,
     Matcher,
 )
@@ -15,11 +15,22 @@ from src import (
 if __name__ == "__main__":
     LoggingManager(Path("app.log"))
     logging.debug("Application started")
+
+    # Load configuration
+    config_path = Path("config.json")
+    config = json.loads(config_path.read_text(encoding="utf-8")) if config_path.exists() else {}
+
     entries = load_literature_entries(Path("data/literature.json"))
     footnotes = load_footnotes(Path("data/footnotes.html"))
 
     status = StatusManager(Path("status.json"))
-    client = LLMClient(DummyAPIClient())
+    client = LLMClient(
+        api_key=config.get("api_key"),
+        model=config.get("model", "gpt-4.1-nano"),
+        max_tokens=config.get("max_tokens", 500),
+        temperature=config.get("temperature", 0.3),
+        request_interval=config.get("request_interval", 1.0),
+    )
     matcher = Matcher(client, status)
 
     result = matcher.match(entries, footnotes)

--- a/src/matching_logic.py
+++ b/src/matching_logic.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import Dict, List
 
 from .data_ingestion import LiteratureEntry, Footnote
@@ -12,6 +13,8 @@ class Matcher:
     def __init__(self, llm_client: LLMClient, status: StatusManager):
         self.llm_client = llm_client
         self.status = status
+        template_path = Path("prompt_templates/basic_prompt.txt")
+        self.base_prompt = template_path.read_text(encoding="utf-8").strip()
 
     def match(self, entries: List[LiteratureEntry], footnotes: List[Footnote]) -> Dict[str, List[str]]:
         logger.info("Starting matching of %d entries", len(entries))
@@ -37,6 +40,10 @@ class Matcher:
 
     def _build_prompt(self, entry: LiteratureEntry, footnotes: List[Footnote]) -> str:
         notes = "\n".join(f"{f.key}: {f.text}" for f in footnotes)
-        prompt = f"Entry: {entry.key} {entry.title}\nFootnotes:\n{notes}"
+        prompt = (
+            f"{self.base_prompt}\n\n"
+            f"Literature entry:\n{entry.key} {entry.title}\n"
+            f"Footnotes:\n{notes}"
+        )
         logger.debug("Built prompt for entry %s: %s", entry.key, prompt)
         return prompt


### PR DESCRIPTION
## Summary
- incorporate `basic_prompt.txt` in every LLM prompt
- enhance instructions in `basic_prompt.txt` to return JSON only
- document prompt template usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fe20d191c8325a6489e35d47e7739