### PR TITLE
Handle duplicate footnotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ status.json
 __pycache__/
 app.log
 .venv
+
+responses/

--- a/README.md
+++ b/README.md
@@ -26,10 +26,43 @@ Beim Einlesen erhalten alle Literatureinträge einen Schlüssel in der Form `L00
    python -m venv .venv
    source .venv/bin/activate
    ```
+
 3. Benötigte Pakete installieren:
    ```bash
    pip install -r requirements.txt
    ```
+
+## Konfiguration
+Im Projektverzeichnis befindet sich eine Datei `config.json` mit den Einstellungen für das LLM. Beispielinhalt:
+
+```json
+{
+  "api_key": "YOUR_API_KEY",
+  "model": "gpt-4.1-nano",
+  "max_tokens": 500,
+  "temperature": 0.3,
+  "request_interval": 1.0,
+  "responses_dir": "responses"
+  }
+```
+
+Ohne `api_key` wird automatisch der `DummyAPIClient` verwendet.
+Der Parameter `request_interval` gibt die minimale Zeit in Sekunden zwischen zwei
+LLM-Aufrufen an und hilft, "Too Many Requests"-Fehler zu vermeiden.
+
+Alle Antworten des LLM werden in das Verzeichnis `responses/` geschrieben. Dieses
+Verzeichnis wird beim Start automatisch geleert, sodass dort nur die Ergebnisse
+des aktuellen Laufs liegen.
+
+Der eigentliche Prompt wird aus der Datei `prompt_templates/basic_prompt.txt`
+gelesen und mit den Informationen zu Eintrag und Fußnoten kombiniert. Dort kann
+der Prompttext angepasst werden.\
+Tritt ein Verweis mehrfach auf, nutzt das Programm zusätzlich
+`prompt_templates/disambiguation_prompt.txt`, um das LLM zu bitten, den
+korrekten Eintrag zu bestimmen. Auch hier darf ausschließlich ein gültiges
+JSON-Objekt ausgegeben werden.
+Schlägt die Auflösung fehl, wird die betreffende Fußnote aus allen Zuordnungen
+entfernt.
 
 ## Ausführung
 Das Programm kann direkt über `run.py` gestartet werden. Es liest die Daten ein, ruft das (hier simulierte) LLM über den `LLMClient` an und schreibt Fortschrittsinformationen in `status.json`. Die Protokollierung wird zentral durch den `LoggingManager` gesteuert.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,8 @@
+{
+  "api_key": "YOUR_API_KEY",
+  "model": "gpt-4.1-nano",
+  "max_tokens": 500,
+  "temperature": 0.3,
+  "request_interval": 1.0,
+  "responses_dir": "responses"
+}

--- a/prompt_templates/basic_prompt.txt
+++ b/prompt_templates/basic_prompt.txt
@@ -1,2 +1,4 @@
 Please map the following footnotes to the literature entry.
-Return JSON in the form {"<entry_key>": ["<footnote_key>", ...]}.
+Return **only** a valid JSON object in the form
+{"<entry_key>": ["<footnote_key>", ...]}.
+Do not include any explanations or additional text.

--- a/prompt_templates/disambiguation_prompt.txt
+++ b/prompt_templates/disambiguation_prompt.txt
@@ -1,0 +1,4 @@
+A footnote appears in multiple literature entries.
+Choose the entry it truly belongs to.
+Return **only** a JSON object of the form {"<footnote_key>": "<entry_key>"}.
+Do not include explanations or additional text.

--- a/run.py
+++ b/run.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import logging
+import json
 
 from src.logging_manager import LoggingManager
 
@@ -7,7 +8,6 @@ from src import (
     load_literature_entries,
     load_footnotes,
     LLMClient,
-    DummyAPIClient,
     StatusManager,
     Matcher,
 )
@@ -15,11 +15,23 @@ from src import (
 if __name__ == "__main__":
     LoggingManager(Path("app.log"))
     logging.debug("Application started")
+
+    # Load configuration
+    config_path = Path("config.json")
+    config = json.loads(config_path.read_text(encoding="utf-8")) if config_path.exists() else {}
+
     entries = load_literature_entries(Path("data/literature.json"))
     footnotes = load_footnotes(Path("data/footnotes.html"))
 
     status = StatusManager(Path("status.json"))
-    client = LLMClient(DummyAPIClient())
+    client = LLMClient(
+        api_key=config.get("api_key"),
+        model=config.get("model", "gpt-4.1-nano"),
+        max_tokens=config.get("max_tokens", 500),
+        temperature=config.get("temperature", 0.3),
+        request_interval=config.get("request_interval", 1.0),
+        responses_dir=Path(config.get("responses_dir", "responses")),
+    )
     matcher = Matcher(client, status)
 
     result = matcher.match(entries, footnotes)

--- a/src/data_ingestion.py
+++ b/src/data_ingestion.py
@@ -56,10 +56,17 @@ def load_footnotes(path: Path) -> List[Footnote]:
     soup = BeautifulSoup(html, "html.parser")
     footnotes = []
     for i, div in enumerate(soup.find_all("div"), start=1):
-        if not div.get("id"):
+        footnote_id = div.get("id")
+        if not footnote_id:
             continue
         key = f"F{i:05d}"
-        footnotes.append(Footnote(footnote_id=div["id"], text=div.get_text(strip=True), key=key))
+        footnotes.append(
+            Footnote(
+                footnote_id=footnote_id,
+                text=footnote_id,
+                key=key,
+            )
+        )
         logger.debug("Loaded footnote %s", key)
     logger.info("Loaded %d footnotes", len(footnotes))
     return footnotes

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -1,6 +1,9 @@
 import json
 import logging
-from typing import Any, Dict
+import time
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -9,34 +12,122 @@ class LLMValidationError(Exception):
 
 
 class LLMClient:
-    def __init__(self, api_client):
+    """Client for interacting with an OpenAI compatible LLM."""
+
+    def __init__(
+        self,
+        api_client: Optional[object] = None,
+        api_key: Optional[str] = None,
+        model: str = "gpt-4.1-nano",
+        max_tokens: int = 500,
+        temperature: float = 0.3,
+        request_interval: float = 1.0,
+        responses_dir: Path | str = Path("responses"),
+    ) -> None:
         self.api_client = api_client
+        self.api_key = api_key
+        self.model = model
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        self.request_interval = request_interval
+        self._last_request_time = 0.0
+        self._lock = Lock()
+        self._client: Optional[object] = None
+        self.responses_dir = Path(responses_dir)
+        self._prepare_responses_dir()
+
+        if self.api_client is None and self.api_key:
+            self._initialize_client()
+        elif self.api_client is None:
+            self.api_client = DummyAPIClient()
+
+    def _save_response(self, name: str, content: str) -> None:
+        """Persist raw or validated LLM output to file."""
+        path = self.responses_dir / name
+        try:
+            path.write_text(content, encoding="utf-8")
+            logger.debug("Saved response to %s", path)
+        except OSError as e:
+            logger.warning("Failed to write response %s: %s", path, e)
+
+    def _prepare_responses_dir(self) -> None:
+        """Create or clear the directory used for storing responses."""
+        if self.responses_dir.exists():
+            for f in self.responses_dir.iterdir():
+                try:
+                    f.unlink()
+                except OSError as e:
+                    logger.warning("Failed to remove %s: %s", f, e)
+        else:
+            self.responses_dir.mkdir(parents=True, exist_ok=True)
+
+    def _wait_for_slot(self) -> None:
+        """Wait until enough time has passed since the last request."""
+        with self._lock:
+            now = time.time()
+            wait = self._last_request_time + self.request_interval - now
+            if wait > 0:
+                time.sleep(wait)
+            self._last_request_time = time.time()
+
+    def _initialize_client(self) -> None:
+        """Initialize OpenAI client."""
+        try:
+            import openai
+
+            self._client = openai.OpenAI(api_key=self.api_key)
+            logger.info("OpenAI client initialized with model %s", self.model)
+        except ImportError:
+            logger.error(
+                "OpenAI package not installed. Install with: pip install openai"
+            )
+            raise
+        except Exception as e:
+            logger.error("Failed to initialize OpenAI client: %s", e)
+            raise
 
     def _send_prompt(self, prompt: str) -> str:
-        """Send prompt using provided API client."""
+        """Send prompt using either the OpenAI client or the provided API client."""
+        self._wait_for_slot()
+        if self._client is not None:
+            try:
+                response = self._client.chat.completions.create(
+                    model=self.model,
+                    messages=[{"role": "system", "content": prompt}],
+                    max_tokens=self.max_tokens,
+                    temperature=self.temperature,
+                )
+                return response.choices[0].message.content
+            except Exception as e:
+                logger.error("OpenAI API call failed: %s", e)
+                raise
         logger.debug("Sending prompt to API: %s", prompt)
-        # This is a placeholder for real API call
         response = self.api_client.send(prompt)
         logger.debug("Received response: %s", response)
         return response
 
-    def query(self, prompt: str) -> Dict[str, Any]:
-        """Send prompt twice and verify matching JSON responses.""" 
+    def query(self, prompt: str, name: str = "response") -> Dict[str, Any]:
+        """Send prompt twice, store responses and verify matching JSON."""
         for attempt in range(2):
-            logger.debug("LLM query attempt %d", attempt + 1)
+            logger.debug("LLM query attempt %d for %s", attempt + 1, name)
             res1 = self._send_prompt(prompt)
+            self._save_response(f"{name}_attempt{attempt+1}_1.txt", res1)
             res2 = self._send_prompt(prompt)
+            self._save_response(f"{name}_attempt{attempt+1}_2.txt", res2)
             try:
                 j1 = json.loads(res1)
                 j2 = json.loads(res2)
             except json.JSONDecodeError:
-                logger.warning("Invalid JSON received")
+                logger.warning("Invalid JSON received for %s", name)
                 continue
             if j1 == j2:
-                logger.info("Received matching JSON responses")
+                logger.info("Received matching JSON responses for %s", name)
+                self._save_response(
+                    f"{name}_validated.json", json.dumps(j1, indent=2)
+                )
                 return j1
-            logger.warning("Responses do not match")
-        logger.error("LLM validation failed")
+            logger.warning("Responses do not match for %s", name)
+        logger.error("LLM validation failed for %s", name)
         raise LLMValidationError("Failed to obtain valid identical responses")
 
 class DummyAPIClient:

--- a/src/matching_logic.py
+++ b/src/matching_logic.py
@@ -1,4 +1,6 @@
 import logging
+from pathlib import Path
+from collections import defaultdict
 from typing import Dict, List
 
 from .data_ingestion import LiteratureEntry, Footnote
@@ -12,6 +14,10 @@ class Matcher:
     def __init__(self, llm_client: LLMClient, status: StatusManager):
         self.llm_client = llm_client
         self.status = status
+        template_path = Path("prompt_templates/basic_prompt.txt")
+        self.base_prompt = template_path.read_text(encoding="utf-8").strip()
+        disamb_path = Path("prompt_templates/disambiguation_prompt.txt")
+        self.disamb_prompt = disamb_path.read_text(encoding="utf-8").strip()
 
     def match(self, entries: List[LiteratureEntry], footnotes: List[Footnote]) -> Dict[str, List[str]]:
         logger.info("Starting matching of %d entries", len(entries))
@@ -23,8 +29,9 @@ class Matcher:
                 chunk = footnotes[i:i+10]
                 logger.debug("Sending chunk %d-%d for entry %s", i, i + len(chunk) - 1, entry.key)
                 prompt = self._build_prompt(entry, chunk)
+                name = f"{entry.key}_chunk{i//10:03d}"
                 try:
-                    response = self.llm_client.query(prompt)
+                    response = self.llm_client.query(prompt, name=name)
                 except Exception as e:
                     logger.error("LLM query failed: %s", e)
                     self.status.update("error", str(e))
@@ -32,11 +39,77 @@ class Matcher:
                 footnote_keys = response.get(entry.key, [])
                 logger.debug("Received %d footnote keys", len(footnote_keys))
                 result.setdefault(entry.key, []).extend(footnote_keys)
+        result = self._resolve_duplicates(result, entries, footnotes)
         logger.info("Finished matching")
         return result
 
     def _build_prompt(self, entry: LiteratureEntry, footnotes: List[Footnote]) -> str:
         notes = "\n".join(f"{f.key}: {f.text}" for f in footnotes)
-        prompt = f"Entry: {entry.key} {entry.title}\nFootnotes:\n{notes}"
+        prompt = (
+            f"{self.base_prompt}\n\n"
+            f"Literature entry:\n{entry.key} {entry.title}\n"
+            f"Footnotes:\n{notes}"
+        )
         logger.debug("Built prompt for entry %s: %s", entry.key, prompt)
         return prompt
+
+    def _build_disambiguation_prompt(
+        self, footnote: Footnote, entries: List[LiteratureEntry]
+    ) -> str:
+        options = "\n".join(f"{e.key}: {e.title}" for e in entries)
+        prompt = (
+            f"{self.disamb_prompt}\n\n"
+            f"Footnote:\n{footnote.key} {footnote.text}\n"
+            f"Entries:\n{options}"
+        )
+        logger.debug(
+            "Built disambiguation prompt for footnote %s: %s", footnote.key, prompt
+        )
+        return prompt
+
+    def _resolve_duplicates(
+        self,
+        matches: Dict[str, List[str]],
+        entries: List[LiteratureEntry],
+        footnotes: List[Footnote],
+    ) -> Dict[str, List[str]]:
+        entry_lookup = {e.key: e for e in entries}
+        footnote_lookup = {f.key: f for f in footnotes}
+
+        occurrences: Dict[str, List[str]] = defaultdict(list)
+        for entry_key, note_keys in matches.items():
+            for fkey in note_keys:
+                occurrences[fkey].append(entry_key)
+
+        duplicates = {fk: ekeys for fk, ekeys in occurrences.items() if len(ekeys) > 1}
+
+        for fkey, ekeys in duplicates.items():
+            footnote = footnote_lookup.get(fkey)
+            if not footnote:
+                continue
+            candidate_entries = [entry_lookup[k] for k in ekeys if k in entry_lookup]
+            prompt = self._build_disambiguation_prompt(footnote, candidate_entries)
+            name = f"{fkey}_disamb"
+
+            try:
+                response = self.llm_client.query(prompt, name=name)
+                chosen = response.get(fkey)
+            except Exception as e:
+                logger.error("Disambiguation query failed: %s", e)
+                chosen = None
+
+            if not chosen or chosen not in ekeys:
+                if chosen and chosen not in ekeys:
+                    logger.warning(
+                        "LLM returned invalid entry %s for footnote %s", chosen, fkey
+                    )
+                # remove footnote from all entries if disambiguation fails
+                for ekey in ekeys:
+                    if fkey in matches.get(ekey, []):
+                        matches[ekey].remove(fkey)
+                continue
+
+            for ekey in ekeys:
+                if ekey != chosen and fkey in matches.get(ekey, []):
+                    matches[ekey].remove(fkey)
+        return matches


### PR DESCRIPTION
## Summary
- add a prompt template for footnote disambiguation
- read the new template in `Matcher`
- introduce duplicate detection and second LLM query to resolve duplicates
- remove footnotes from all entries when disambiguation fails
- document duplicate removal behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fe20d191c8325a6489e35d47e7739