### PR TITLE
Fix prompt formatting and improve footnote ingestion

### DIFF
--- a/src/data_ingestion.py
+++ b/src/data_ingestion.py
@@ -60,10 +60,14 @@ def load_footnotes(path: Path) -> List[Footnote]:
         if not footnote_id:
             continue
         key = f"F{i:05d}"
+        text = div.get_text(strip=True)
+        if not text:
+            logger.debug("Skipping footnote %s with empty text", footnote_id)
+            continue
         footnotes.append(
             Footnote(
                 footnote_id=footnote_id,
-                text=footnote_id,
+                text=text,
                 key=key,
             )
         )

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -43,19 +43,25 @@ class LLMClient:
 
     def _save_response(self, name: str, content: str) -> None:
         """Persist raw or validated LLM output to file."""
-        # path = self.responses_dir / name
-        # try:
-        #     path.write_text(content, encoding="utf-8")
-        #     logger.debug("Saved response to %s", path)
-        # except OSError as e:
-        #     logger.warning("Failed to write response %s: %s", path, e)
+        path = self.responses_dir / name
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+            logger.debug("Saved response to %s", path)
+        except OSError as e:
+            logger.warning("Failed to write response %s: %s", path, e)
 
     def _prepare_responses_dir(self) -> None:
         """Create or clear the directory used for storing responses."""
         if self.responses_dir.exists():
             for f in self.responses_dir.iterdir():
                 try:
-                    f.unlink()
+                    if f.is_file():
+                        f.unlink()
+                    elif f.is_dir():
+                        import shutil
+
+                        shutil.rmtree(f)
                 except OSError as e:
                     logger.warning("Failed to remove %s: %s", f, e)
         else:

--- a/src/matching_logic.py
+++ b/src/matching_logic.py
@@ -45,10 +45,16 @@ class Matcher:
 
     def _build_prompt(self, entry: LiteratureEntry, footnotes: List[Footnote]) -> str:
         notes = "\n".join(f"{f.key}: {f.text}" for f in footnotes)
-        prompt = (
-            f"{self.base_prompt}\n\n"
-            f"Literature entry:\nKey:{entry.key} FirstName:{entry.author_first} LastName:{entry.author_last} Year:{entry.year}\n"
-            f"Footnotes:\n{notes}"
+        prompt = "".join(
+            (
+                f"{self.base_prompt}\n\n",
+                "Literature entry:\n",
+                f"Key:{entry.key} ",
+                f"FirstName:{entry.author_first} ",
+                f"LastName:{entry.author_last} ",
+                f"Year:{entry.year}\n",
+                f"Footnotes:\n{notes}",
+            )
         )
         logger.debug("Built prompt for entry %s: %s", entry.key, prompt)
         return prompt
@@ -56,11 +62,24 @@ class Matcher:
     def _build_disambiguation_prompt(
         self, footnote: Footnote, entries: List[LiteratureEntry]
     ) -> str:
-        options = "\n".join(f"Literature entry:\nKey:{e.key} FirstName:{e.author_first} LastName:{e.author_last} Year:{e.year}\n" for e in entries)
-        prompt = (
-            f"{self.disamb_prompt}\n\n"
-            f"Footnote:\n{footnote.key} {footnote.text}\n"
-            f"Entries:\n{options}"
+        options = "\n".join(
+            "".join(
+                (
+                    "Literature entry:\n",
+                    f"Key:{e.key} ",
+                    f"FirstName:{e.author_first} ",
+                    f"LastName:{e.author_last} ",
+                    f"Year:{e.year}\n",
+                )
+            )
+            for e in entries
+        )
+        prompt = "".join(
+            (
+                f"{self.disamb_prompt}\n\n",
+                f"Footnote:\n{footnote.key} {footnote.text}\n",
+                f"Entries:\n{options}",
+            )
         )
         logger.debug(
             "Built disambiguation prompt for footnote %s: %s", footnote.key, prompt


### PR DESCRIPTION
## Summary
- correct the prompt construction for both matching and disambiguation requests to avoid malformed strings
- extract real footnote content from the HTML input and skip empty entries during ingestion
- restore response persistence and safely reset the responses directory for LLM interactions

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68f237c930a08325a075523195ec57f7